### PR TITLE
ENH: Require cmake minimum version to be 3.9.5.

### DIFF
--- a/Admin/ITKCMakeLists
+++ b/Admin/ITKCMakeLists
@@ -1,7 +1,7 @@
 ==CMakeLists.txt==
 {{#tag:syntaxhighlight
 |
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.9.5)
 
 project({{{1}}})
 

--- a/Admin/ITKVTKCMakeLists
+++ b/Admin/ITKVTKCMakeLists
@@ -1,7 +1,7 @@
 ==CMakeLists.txt==
 {{#tag:syntaxhighlight
 |
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.9.5)
  
 project({{{1}}})
  

--- a/CMake/SampleBuildTest.cmake.in
+++ b/CMake/SampleBuildTest.cmake.in
@@ -9,7 +9,7 @@ set(CTEST_BUILD_CONFIGURATION "Debug")
 set(CTEST_BUILD_CONFIGURATION "RelWithDebinfo")
 
 
-cmake_minimum_required(VERSION 2.8.1)
+cmake_minimum_required(VERSION 3.9.5)
 
 set(CTEST_SOURCE_DIRECTORY "@WikiExamples_SOURCE_DIR@")
 set(CTEST_BINARY_DIRECTORY "@WikiExamples_BINARY_DIR@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
  
 project(ITKWikiExamples)
 if (Fetch_WikiExamples OR Module_WikiExamples)

--- a/DICOM/CMakeLists.txt
+++ b/DICOM/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required(VERSION 3.9.5)
 
 project (DICOM)
 

--- a/ItkVtkGlue/CMakeLists.txt
+++ b/ItkVtkGlue/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.9.5)
 project (ItkVtkGlue)
 
 if(NOT ITKWikiExamples_BINARY_DIR)

--- a/Superbuild/CMakeLists.txt
+++ b/Superbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.9.5)
 if(COMMAND CMAKE_POLICY)
   cmake_policy(SET CMP0003 NEW)
 endif()


### PR DESCRIPTION
Require CMake minimum version to be 3.9.5 following ITKv5 requiring
C++11:
https://discourse.itk.org/t/minimum-cmake-version-update/585