### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/ItkVtkGlue/itkImageToVTKImageFilter.h
+++ b/ItkVtkGlue/itkImageToVTKImageFilter.h
@@ -41,6 +41,8 @@ template <class TInputImage >
 class ImageToVTKImageFilter : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ImageToVTKImageFilter);
+
   /** Standard class type alias. */
   using Self = ImageToVTKImageFilter;
   using Superclass = ProcessObject;
@@ -86,9 +88,6 @@ protected:
   virtual ~ImageToVTKImageFilter();
 
 private:
-  ImageToVTKImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   ExporterFilterPointer       m_Exporter;
   vtkImageImport *            m_Importer;
 };


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.