### PR TITLE
COMP: Set the minimum required CMake version to 3.10.2.

### DIFF
--- a/DICOM/CMakeLists.txt
+++ b/DICOM/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.10.2)
 
 project (DICOM)
 

--- a/ItkVtkGlue/CMakeLists.txt
+++ b/ItkVtkGlue/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.10.2)
 project (ItkVtkGlue)
 
 if(NOT ITKWikiExamples_BINARY_DIR)

--- a/Superbuild/CMakeLists.txt
+++ b/Superbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.10.2)
 if(COMMAND CMAKE_POLICY)
   cmake_policy(SET CMP0003 NEW)
 endif()


### PR DESCRIPTION
As agreed in:
https://discourse.itk.org/t/cmake-update/870/

Set the `cmake_minimum_required` to version **3.10.2**.