### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/Broken/EdgesAndGradients/CannyEdgeDetectionImageFilter.cxx
+++ b/Broken/EdgesAndGradients/CannyEdgeDetectionImageFilter.cxx
@@ -21,15 +21,15 @@ int main(int argc, char *argv[])
   double lowerThreshold = 0.0;
   if (argc > 2)
     {
-    variance = atof(argv[2]);
+    variance = std::stod(argv[2]);
     }
   if (argc > 3)
     {
-    lowerThreshold = atof(argv[3]);
+    lowerThreshold = std::stod(argv[3]);
     }
   if (argc > 4)
     {
-    upperThreshold = atof(argv[4]);
+    upperThreshold = std::stod(argv[4]);
     }
 
   using DoubleImageType = itk::Image<double, 2>;

--- a/DICOM/ResampleDICOM.cxx
+++ b/DICOM/ResampleDICOM.cxx
@@ -144,9 +144,9 @@ int main( int argc, char* argv[] )
   // used. The size (# of pixels) in the output is recomputed using
   // the ratio of the input and output sizes.
   InputImageType::SpacingType outputSpacing;
-  outputSpacing[0] = atof(argv[3]);
-  outputSpacing[1] = atof(argv[4]);
-  outputSpacing[2] = atof(argv[5]);
+  outputSpacing[0] = std::stod(argv[3]);
+  outputSpacing[1] = std::stod(argv[4]);
+  outputSpacing[2] = std::stod(argv[5]);
 
   bool changeInSpacing = false;
   for (unsigned int i = 0; i < 3; i++)

--- a/Developer/OilPaintingImageFilter.cxx
+++ b/Developer/OilPaintingImageFilter.cxx
@@ -15,13 +15,13 @@ int main(int argc, char*argv[])
   unsigned int numberOfBins = 50;
   if (argc > 3)
     {
-    numberOfBins = atoi(argv[2]);
+    numberOfBins = std::stoi(argv[2]);
     }
 
   unsigned int radius = 2;
   if (argc > 4)
     {
-    radius = atoi(argv[3]);
+    radius = std::stoi(argv[3]);
     }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/EdgesAndGradients/ZeroCrossingBasedEdgeDetectionImageFilter.cxx
+++ b/EdgesAndGradients/ZeroCrossingBasedEdgeDetectionImageFilter.cxx
@@ -20,7 +20,7 @@ int main(int argc, char * argv[])
   double var = 5.0;
   if (argc > 2)
     {
-    var = atof(argv[2]);
+    var = std::stod(argv[2]);
     }
 
     // Parse command line arguments

--- a/Functions/GaussianBlurImageFunction.cxx
+++ b/Functions/GaussianBlurImageFunction.cxx
@@ -43,8 +43,8 @@ int main( int argc, char * argv[] )
   GFunctionType::ErrorArrayType setError;
   setError.Fill( 0.01 );
   gaussianFunction->SetMaximumError( setError );
-  gaussianFunction->SetSigma( atof( argv[3] ) );
-  gaussianFunction->SetMaximumKernelWidth( atoi( argv[4] ) );
+  gaussianFunction->SetSigma( std::stod( argv[3] ) );
+  gaussianFunction->SetMaximumKernelWidth( std::stoi( argv[4] ) );
 
   it.GoToBegin();
   out.GoToBegin();

--- a/IO/VolumeFromSlices.cxx
+++ b/IO/VolumeFromSlices.cxx
@@ -25,8 +25,8 @@ int main( int argc, char * argv[] )
   ReaderType::Pointer reader = ReaderType::New();
   WriterType::Pointer writer = WriterType::New();
 
-  const unsigned int first = atoi( argv[2] );
-  const unsigned int last  = atoi( argv[3] );
+  const unsigned int first = std::stoi( argv[2] );
+  const unsigned int last  = std::stoi( argv[3] );
 
   const char * outputFilename = argv[4];
 

--- a/ImageProcessing/BinaryThresholdImageFilter.cxx
+++ b/ImageProcessing/BinaryThresholdImageFilter.cxx
@@ -17,11 +17,11 @@ int main(int argc, char *argv[])
   int upperThreshold = 30;
   if (argc > 2)
     {
-    lowerThreshold = atoi(argv[2]);
+    lowerThreshold = std::stoi(argv[2]);
     }
   if (argc > 3)
     {
-    upperThreshold = atoi(argv[3]);
+    upperThreshold = std::stoi(argv[3]);
     }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/ImageProcessing/ConvolutionImageFilter.cxx
+++ b/ImageProcessing/ConvolutionImageFilter.cxx
@@ -23,7 +23,7 @@ int main(int argc, char * argv[])
   unsigned int width = 3;
   if (argc > 2)
     {
-    width = atoi(argv[2]);
+    width = std::stoi(argv[2]);
     }
 
   ImageType::Pointer kernel = ImageType::New();

--- a/ImageProcessing/CropImageFilter.cxx
+++ b/ImageProcessing/CropImageFilter.cxx
@@ -25,8 +25,8 @@ int main(int argc, char *argv[])
     reader->SetFileName( argv[1] );
     if (argc > 2)
       {
-      cropSize[0] = atoi(argv[2]);
-      cropSize[1] = atoi(argv[3]);
+      cropSize[0] = std::stoi(argv[2]);
+      cropSize[1] = std::stoi(argv[3]);
       }
     reader->Update();
     image = reader->GetOutput();

--- a/ImageProcessing/InvertIntensityImageFilter.cxx
+++ b/ImageProcessing/InvertIntensityImageFilter.cxx
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
     desc << itksys::SystemTools::GetFilenameName(argv[1]);
     if (argc > 2)
       {
-      maximum = atoi(argv[2]);
+      maximum = std::stoi(argv[2]);
       }
     }
   else

--- a/ImageProcessing/LabelGeometryImageFilter.cxx
+++ b/ImageProcessing/LabelGeometryImageFilter.cxx
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
 
     intensityImage = intensityReader->GetOutput();
 
-    label = atoi(argv[3]);
+    label = std::stoi(argv[3]);
     }
 
   // NOTE: As of April 8, 2015 the filter does not work with non-zero

--- a/ImageProcessing/RGBResampleImageFilter.cxx
+++ b/ImageProcessing/RGBResampleImageFilter.cxx
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
     input = reader->GetOutput();
     if (argc > 2)
       {
-      factor = atof(argv[2]);
+      factor = std::stod(argv[2]);
       }
   }
 

--- a/ImageProcessing/ResampleSegmentedImage.cxx
+++ b/ImageProcessing/ResampleSegmentedImage.cxx
@@ -34,7 +34,7 @@ int main( int argc, char * argv[] )
     
     return EXIT_FAILURE;
     }
-  double spacing = atof(argv[2]);
+  double spacing = std::stod(argv[2]);
  
   using ReaderType = itk::ImageFileReader<ImageType>;
  

--- a/ImageProcessing/ScalarConnectedComponentImageFilter.cxx
+++ b/ImageProcessing/ScalarConnectedComponentImageFilter.cxx
@@ -65,7 +65,7 @@ int main( int argc, char *argv[])
   RelabelFilterType::ObjectSizeType minSize = 20;
   if (argc > 3)
     {
-    minSize = atoi(argv[3]);
+    minSize = std::stoi(argv[3]);
     }
   relabel->SetInput(connected->GetOutput());
   relabel->SetMinimumObjectSize(minSize);

--- a/ImageProcessing/SigmoidImageFilter.cxx
+++ b/ImageProcessing/SigmoidImageFilter.cxx
@@ -17,11 +17,11 @@ int main(int argc, char *argv[])
   double beta = 10.0;
   if (argc > 2)
     {
-    alpha = atof(argv[2]);
+    alpha = std::stod(argv[2]);
     }
   if (argc > 3)
     {
-    beta = atof(argv[3]);
+    beta = std::stod(argv[3]);
     }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/ImageProcessing/ThresholdImageFilter.cxx
+++ b/ImageProcessing/ThresholdImageFilter.cxx
@@ -18,11 +18,11 @@ int main(int argc, char *argv[])
   int upperThreshold = 30;
   if (argc > 2)
     {
-    lowerThreshold = atoi(argv[2]);
+    lowerThreshold = std::stoi(argv[2]);
     }
   if (argc > 3)
     {
-    upperThreshold = atoi(argv[3]);
+    upperThreshold = std::stoi(argv[3]);
     }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/ImageProcessing/Upsampling.cxx
+++ b/ImageProcessing/Upsampling.cxx
@@ -113,8 +113,8 @@ int main( int argc, char * argv[] )
   //     done at step 2 there:
   //       http://itk.org/Wiki/ITK/Examples/DICOM/ResampleDICOM)
   //
-  unsigned int nNewWidth = atoi(argv[3]);
-  unsigned int nNewHeight = atoi(argv[4]);
+  unsigned int nNewWidth = std::stoi(argv[3]);
+  unsigned int nNewHeight = std::stoi(argv[4]);
  
   // Fetch original image size.
   const T_Image::RegionType& inputRegion = 

--- a/ImageSegmentation/ConfidenceConnectedImageFilter.cxx
+++ b/ImageSegmentation/ConfidenceConnectedImageFilter.cxx
@@ -33,8 +33,8 @@ int main( int argc, char *argv[])
 
   // Set seed
   ImageType::IndexType seed;
-  seed[0] = atoi(argv[2]);
-  seed[1] = atoi(argv[3]);
+  seed[0] = std::stoi(argv[2]);
+  seed[1] = std::stoi(argv[3]);
   confidenceConnectedFilter->SetSeed(seed);
   confidenceConnectedFilter->SetInput(reader->GetOutput());
 

--- a/ImageSegmentation/ExtractContourWithSnakes.cxx
+++ b/ImageSegmentation/ExtractContourWithSnakes.cxx
@@ -82,12 +82,12 @@ int main( int argc, char* argv[] )
   int nPoints = 20;
   double sigma;
 
-  nPoints = atoi(argv[1]);
-  alpha = atof(argv[2]);
-  beta = atof(argv[3]);
-  gamma = atof(argv[4]);
-  sigma = atof(argv[5]);
-  iterations = atoi(argv[6]);
+  nPoints = std::stoi(argv[1]);
+  alpha = std::stod(argv[2]);
+  beta = std::stod(argv[3]);
+  gamma = std::stod(argv[4]);
+  sigma = std::stod(argv[5]);
+  iterations = std::stoi(argv[6]);
 
   // Temporal variables
   vnl_matrix<double> P;

--- a/Inspection/PixelInspection.cxx
+++ b/Inspection/PixelInspection.cxx
@@ -34,8 +34,8 @@ int main( int argc, char * argv [] )
 
   ImageType::IndexType index;
 
-  index[0] = atoi( argv[2] );
-  index[1] = atoi( argv[3] );
+  index[0] = std::stoi( argv[2] );
+  index[1] = std::stoi( argv[3] );
 
   const PixelType value = inputImage->GetPixel( index );
 

--- a/Meshes/QuadEdgeMeshNormalFilter.cxx
+++ b/Meshes/QuadEdgeMeshNormalFilter.cxx
@@ -42,7 +42,7 @@ int main( int argc, char* argv[] )
   using NormalFilterType = itk::NormalQuadEdgeMeshFilter< InputMeshType, OutputMeshType >;
   NormalFilterType::WeightType weight_type;
 
-  int param = atoi( argv[2] );
+  int param = std::stoi( argv[2] );
 
   if( ( param < 0 ) || ( param > 2 ) )
     {

--- a/Meshes/ReadWrite.cxx
+++ b/Meshes/ReadWrite.cxx
@@ -23,7 +23,7 @@ int main(int argc, char * argv[] )
   // If the integer is less than zero, zero will be used.
   // If the integer is greater than seven, seven will be used.
   int i = 0;
-  if (argc == 2) i = atoi(argv[1]);
+  if (argc == 2) i = std::stoi(argv[1]);
   i = std::max(std::min(i,8),0);
 
   // Create a string using the appropriate file extension.

--- a/Morphology/BinaryDilateImageFilter.cxx
+++ b/Morphology/BinaryDilateImageFilter.cxx
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
   unsigned int radius = 2;
   if (argc > 2)
     {
-    radius = atoi(argv[2]);
+    radius = std::stoi(argv[2]);
     }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/Morphology/BinaryErodeImageFilter.cxx
+++ b/Morphology/BinaryErodeImageFilter.cxx
@@ -17,7 +17,7 @@ int main(int argc, char *argv[])
   unsigned int radius = 2;
   if (argc > 2)
     {
-    radius = atoi(argv[2]);
+    radius = std::stoi(argv[2]);
     }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/Morphology/FlatStructuringElement.cxx
+++ b/Morphology/FlatStructuringElement.cxx
@@ -15,7 +15,7 @@ int main(int argc, char *argv[])
   unsigned int radius = 2;
   if (argc > 2)
     {
-    radius = atoi(argv[2]);
+    radius = std::stoi(argv[2]);
     }
 
   using ImageType = itk::Image<unsigned char, 2>;

--- a/Morphology/GrayscaleDilateImageFilter.cxx
+++ b/Morphology/GrayscaleDilateImageFilter.cxx
@@ -20,7 +20,7 @@ int main(int argc, char *argv[])
   unsigned int radius = 2;
   if (argc > 2)
     {
-    radius = atoi(argv[2]);
+    radius = std::stoi(argv[2]);
     }
 
   std::string inputFilename = argv[1];

--- a/Morphology/GrayscaleErodeImageFilter.cxx
+++ b/Morphology/GrayscaleErodeImageFilter.cxx
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
   unsigned int radius = 2;
   if (argc > 2)
     {
-    radius = atoi(argv[2]);
+    radius = std::stoi(argv[2]);
     }
 
   using StructuringElementType = itk::BinaryBallStructuringElement<

--- a/Segmentation/OtsuMultipleThresholdsImageFilter.cxx
+++ b/Segmentation/OtsuMultipleThresholdsImageFilter.cxx
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
     reader->Update();
     if (argc > 2)
       {
-      numberOfThresholds = atoi(argv[2]);
+      numberOfThresholds = std::stoi(argv[2]);
       }
     image = reader->GetOutput();
     }

--- a/Smoothing/BilateralImageFilter.cxx
+++ b/Smoothing/BilateralImageFilter.cxx
@@ -18,11 +18,11 @@ int main(int argc, char * argv[])
   double domainSigma = 2.0;
   if (argc > 2)
     {
-    domainSigma = atof(argv[2]);
+    domainSigma = std::stod(argv[2]);
     }
   if (argc > 3)
     {
-    rangeSigma = atof(argv[3]);
+    rangeSigma = std::stod(argv[3]);
     }
 
   // Parse command line arguments

--- a/Smoothing/BinaryMinMaxCurvatureFlowImageFilter.cxx
+++ b/Smoothing/BinaryMinMaxCurvatureFlowImageFilter.cxx
@@ -20,7 +20,7 @@ int main(int argc, char* argv[])
   unsigned int numberOfIterations = 2;
   if (argc > 2)
     {
-    numberOfIterations = atoi(argv[2]);
+    numberOfIterations = std::stoi(argv[2]);
     }
 
   constexpr unsigned int Dimension = 2;

--- a/Smoothing/BinomialBlurImageFilter.cxx
+++ b/Smoothing/BinomialBlurImageFilter.cxx
@@ -19,7 +19,7 @@ int main(int argc, char * argv[])
   int repetitions = 2;
   if (argc > 2)
     {
-    repetitions = atoi(argv[2]);
+    repetitions = std::stoi(argv[2]);
     }
 
   // Setup types

--- a/Smoothing/CurvatureFlowImageFilter.cxx
+++ b/Smoothing/CurvatureFlowImageFilter.cxx
@@ -18,7 +18,7 @@ int main( int argc, char *argv[])
   int iterations = 5;
   if (argc > 2)
     {
-    iterations = atoi(argv[2]);
+    iterations = std::stoi(argv[2]);
     }
 
   using InternalPixelType = float;

--- a/Smoothing/DiscreteGaussianImageFilter.cxx
+++ b/Smoothing/DiscreteGaussianImageFilter.cxx
@@ -20,7 +20,7 @@ int main(int argc, char * argv[])
   double variance = 4.0;
   if (argc > 2)
     {
-    variance = atof(argv[2]);
+    variance = std::stod(argv[2]);
     }
 
   // Setup types

--- a/Smoothing/SmoothingRecursiveGaussianImageFilter.cxx
+++ b/Smoothing/SmoothingRecursiveGaussianImageFilter.cxx
@@ -20,7 +20,7 @@ int main(int argc, char * argv[])
   double sigma = 4.0;
   if (argc > 2)
     {
-    sigma = atof(argv[2]);
+    sigma = std::stod(argv[2]);
     }
 
 

--- a/Utilities/AddNoiseToBinaryImage.cxx
+++ b/Utilities/AddNoiseToBinaryImage.cxx
@@ -15,7 +15,7 @@ int main (int argc, char *argv[])
   double percent = .1;
   if (argc > 3)
     {
-    percent = atof(argv[3]);
+    percent = std::stod(argv[3]);
     if (percent >= 1.0)
       {
       percent /= 100.0;

--- a/WishList/Segmentation/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation.cxx
+++ b/WishList/Segmentation/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation.cxx
@@ -24,11 +24,11 @@ int main(int argc, char**argv)
   unsigned int nb_iteration = 50;
   double rms = 0.;
   double epsilon = 1.5;
-  double curvature_weight = atof( argv[6] );
-  double area_weight = atof( argv[7] );
-  double volume_weight = atof( argv[8] );
-  double volume = atof( argv[9] );
-  double overlap_weight = atof( argv[10] );
+  double curvature_weight = std::stod( argv[6] );
+  double area_weight = std::stod( argv[7] );
+  double volume_weight = std::stod( argv[8] );
+  double volume = std::stod( argv[9] );
+  double overlap_weight = std::stod( argv[10] );
   double l1 = 1.;
   double l2 = 1.;
 

--- a/WishList/Segmentation/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation.cxx
+++ b/WishList/Segmentation/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation.cxx
@@ -121,10 +121,10 @@ int main(int argc, char**argv)
 
   InternalImageType::IndexType  seedPosition;
 
-  seedPosition[0] = atoi( argv[3] );
-  seedPosition[1] = atoi( argv[4] );
+  seedPosition[0] = std::stoi( argv[3] );
+  seedPosition[1] = std::stoi( argv[4] );
 
-  const double initialDistance = atof( argv[5] );
+  const double initialDistance = std::stod( argv[5] );
 
   NodeType node;
 

--- a/WishList/Segmentation/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation.cxx
+++ b/WishList/Segmentation/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation.cxx
@@ -118,10 +118,10 @@ int main(int argc, char**argv)
 
   InternalImageType::IndexType  seedPosition;
 
-  seedPosition[0] = atoi( argv[3] );
-  seedPosition[1] = atoi( argv[4] );
+  seedPosition[0] = std::stoi( argv[3] );
+  seedPosition[1] = std::stoi( argv[4] );
 
-  const double initialDistance = atof( argv[5] );
+  const double initialDistance = std::stod( argv[5] );
 
   NodeType node;
 

--- a/WishList/Segmentation/kMeansClustering.cxx
+++ b/WishList/Segmentation/kMeansClustering.cxx
@@ -21,8 +21,8 @@ int main( int argc, char * argv [] )
   //parse command line arguments
   const char * inputImageFileName = argv[1];
   const char * outputImageFileName = argv[2];
-  const unsigned int useNonContiguousLabels = atoi( argv[3] );
-  const unsigned int numberOfInitialClasses = atoi( argv[4] );
+  const unsigned int useNonContiguousLabels = std::stoi( argv[3] );
+  const unsigned int numberOfInitialClasses = std::stoi( argv[4] );
   
   constexpr unsigned int argoffset = 5;
 
@@ -39,7 +39,7 @@ int main( int argc, char * argv [] )
   std::vector<double> userMeans;
   for( unsigned k = 0; k < numberOfInitialClasses; k++ )
     {
-    const double userProvidedInitialMean = atof( argv[k+argoffset] );
+    const double userProvidedInitialMean = std::stod( argv[k+argoffset] );
     userMeans.push_back(userProvidedInitialMean);
     }
     


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/