### PR TITLE
COMP: Fix unused `argc` and `argv` variable warnings.

### DIFF
--- a/Registration/DeformationFieldTransform.cxx
+++ b/Registration/DeformationFieldTransform.cxx
@@ -19,7 +19,7 @@ using ImageType = itk::Image< PixelType, Dimension >;
 static void CreateFixedImage(ImageType::Pointer image);
 static void CreateMovingImage(ImageType::Pointer image);
   
-int main(int argc, char * argv[])
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
 #if ITK_VERSION_MAJOR < 4
   using VectorComponentType = float;

--- a/Registration/ImageRegistrationMethodBSpline.cxx
+++ b/Registration/ImageRegistrationMethodBSpline.cxx
@@ -25,7 +25,7 @@ using ImageType = itk::Image< PixelType, ImageDimension >;
 static void CreateEllipseImage(ImageType::Pointer image);
 static void CreateCircleImage(ImageType::Pointer image);
 
-int main( int argc, char *argv[] )
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
 
   const unsigned int SpaceDimension = ImageDimension;

--- a/Registration/LandmarkBasedTransformInitializer.cxx
+++ b/Registration/LandmarkBasedTransformInitializer.cxx
@@ -12,7 +12,7 @@ using ImageType = itk::Image< PixelType, Dimension >;
 static void CreateFixedImage(ImageType::Pointer image);
 static void CreateMovingImage(ImageType::Pointer image);
   
-int main(int argc, char * argv[])
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   using VectorComponentType = float;
 

--- a/Registration/MutualInformation.cxx
+++ b/Registration/MutualInformation.cxx
@@ -19,7 +19,7 @@ using ImageType = itk::Image< PixelType, Dimension >;
 static void CreateEllipseImage(ImageType::Pointer image);
 static void CreateCircleImage(ImageType::Pointer image);
 
-int main( int argc, char *argv[] )
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   // Generate synthetic fixed and moving images
   ImageType::Pointer  fixedImage = ImageType::New();

--- a/Registration/MutualInformationAffine.cxx
+++ b/Registration/MutualInformationAffine.cxx
@@ -19,7 +19,7 @@ using ImageType = itk::Image< PixelType, Dimension >;
 static void CreateEllipseImage(ImageType::Pointer image);
 static void CreateCircleImage(ImageType::Pointer image);
 
-int main( int argc, char *argv[] )
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   // Generate synthetic fixed and moving images
   ImageType::Pointer  fixedImage = ImageType::New();

--- a/SimpleOperations/BresenhamLine.cxx
+++ b/SimpleOperations/BresenhamLine.cxx
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
 static void Vector();
 static void Line();
 
-int main(int argc, char *argv[])
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   Vector();
   Line();

--- a/SimpleOperations/ParaviewColormap.cxx
+++ b/SimpleOperations/ParaviewColormap.cxx
@@ -12,7 +12,7 @@ using RGBImageType = itk::Image<RGBPixelType, 2>;
 using FloatImageType = itk::Image<float, 2>;
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-int main( int argc, char *argv[])
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   FloatImageType::Pointer image = FloatImageType::New();
 

--- a/SimpleOperations/RGBPixel.cxx
+++ b/SimpleOperations/RGBPixel.cxx
@@ -1,7 +1,7 @@
 #include <itkImage.h>
 #include <itkRGBPixel.h>
 
-int main(int argc, char *argv[])
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   using RGBPixelType = itk::RGBPixel<unsigned char>;
   using RGBImageType = itk::Image<RGBPixelType>;

--- a/SimpleOperations/ScalarToRGBColormapImageFilter.cxx
+++ b/SimpleOperations/ScalarToRGBColormapImageFilter.cxx
@@ -11,7 +11,7 @@ using RGBImageType = itk::Image<RGBPixelType, 2>;
 using FloatImageType = itk::Image<float, 2>;
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-int main( int argc, char *argv[])
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   FloatImageType::Pointer image = FloatImageType::New();
 

--- a/SimpleOperations/TranslationTransform.cxx
+++ b/SimpleOperations/TranslationTransform.cxx
@@ -11,7 +11,7 @@ using ImageType = itk::Image<unsigned char, 2>;
 
 static void CreateImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/SpatialObjects/BlobSpatialObject.cxx
+++ b/SpatialObjects/BlobSpatialObject.cxx
@@ -1,6 +1,6 @@
 #include "itkBlobSpatialObject.h"
 
-int main( int argc, char *argv[] )
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   using BlobType = itk::BlobSpatialObject<2>;
 

--- a/SpatialObjects/LineSpatialObject.cxx
+++ b/SpatialObjects/LineSpatialObject.cxx
@@ -3,7 +3,7 @@
 #include "itkLineSpatialObjectPoint.h"
 #include "itkImageFileWriter.h"
 
-int main( int argc, char *argv[] )
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   using PixelType = unsigned char;
   constexpr unsigned int Dimension = 2;

--- a/SpatialObjects/PlaneSpatialObject.cxx
+++ b/SpatialObjects/PlaneSpatialObject.cxx
@@ -2,7 +2,7 @@
 #include "itkPlaneSpatialObject.h"
 #include "itkImageFileWriter.h"
 
-int main( int argc, char *argv[] )
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   constexpr unsigned int Dimension = 2;
 

--- a/SpectralAnalysis/RealAndImaginaryToComplexImageFilter.cxx
+++ b/SpectralAnalysis/RealAndImaginaryToComplexImageFilter.cxx
@@ -8,7 +8,7 @@
 
 #include <complex>
 
-int main( int argc, char *argv[] )
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   using ImageType = itk::Image<unsigned char, 2>;
   using ComplexImageType = itk::Image<std::complex<float>, 2>;

--- a/Statistics/NoiseImageFilter.cxx
+++ b/Statistics/NoiseImageFilter.cxx
@@ -6,7 +6,7 @@ using ImageType = itk::Image<float, 2>;
 
 void CreateImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/Statistics/StatisticsImageFilter.cxx
+++ b/Statistics/StatisticsImageFilter.cxx
@@ -7,7 +7,7 @@ using ImageType = itk::Image<unsigned char, 2>;
 
 static void CreateImage(ImageType::Pointer image);
 
-int main(int argc, char*argv[])
+int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);


### PR DESCRIPTION
Fix unused `argc` and `argv` variable warnings. Fixes:
```
In file included from
-WikiExamples/Modules/Remote/WikiExamples/Registration/TestDeformationFieldTransform.cxx:2:
ITK/Modules/Remote/WikiExamples/Registration/DeformationFieldTransform.cxx:
In function 'int TestDeformationFieldTransform(int, char**)':
[CTest: warning matched]
Modules/Remote/WikiExamples/Registration/DeformationFieldTransform.cxx:22:14:
warning: unused parameter 'argc' [-Wunused-parameter]
int main(int argc, char * argv[])
         ~~~~^~~~
[CTest: warning matched]
Modules/Remote/WikiExamples/Registration/DeformationFieldTransform.cxx:22:27:
warning: unused parameter 'argv' [-Wunused-parameter]
int main(int argc, char * argv[])
                   ~~~~~~~^~~~~~
```

-like warnings reported at:
http://testing.cdash.org/viewBuildError.php?type=1&buildid=5793174