### PR TITLE
COMP: Use `std::abs` over `vnl_math_abs`.

### DIFF
--- a/Morphology/FlatStructuringElementRadiusIsParametric.cxx
+++ b/Morphology/FlatStructuringElementRadiusIsParametric.cxx
@@ -169,7 +169,7 @@ bool ComputeAreaError(SEType k, unsigned int thickness)
   std::cout << "Expected foreground area: " << expectedForegroundArea << std::endl;
   std::cout << "Computed foreground area: " << computedForegroundArea << std::endl;
   std::cout << "Foreground area error: "
-  << 100 * vnl_math_abs(expectedForegroundArea-computedForegroundArea)/expectedForegroundArea
+  << 100 * std::abs(expectedForegroundArea-computedForegroundArea)/expectedForegroundArea
   << "%" << "\n\n";
   
   return EXIT_FAILURE;


### PR DESCRIPTION
Use `std::abs` over `vnl_math_abs`. Fixes:
```
Modules/Remote/WikiExamples/Morphology/FlatStructuringElementRadiusIsParametric.cxx:172:12:
error: there are no arguments to 'vnl_math_abs' that depend on a template
parameter, so a declaration of 'vnl_math_abs' must be available
[-fpermissive]
   << 100 *
   vnl_math_abs(expectedForegroundArea-computedForegroundArea)/expectedForegroundArea
               ^~~~~~~~~~~~

Modules/Remote/WikiExamples/Morphology/FlatStructuringElementRadiusIsParametric.cxx:172:24:
error: 'vnl_math_abs' was not declared in this scope
   << 100 *
   vnl_math_abs(expectedForegroundArea-computedForegroundArea)/expectedForegroundArea
               ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

signaled at:
https://open.cdash.org/viewBuildError.php?buildid=5807048