### PR TITLE
COMP: Fix unused type alias.

### DIFF
--- a/Registration/LandmarkBasedTransformInitializer.cxx
+++ b/Registration/LandmarkBasedTransformInitializer.cxx
@@ -14,8 +14,6 @@ static void CreateMovingImage(ImageType::Pointer image);
   
 int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 {
-  using VectorComponentType = float;
-
   ImageType::Pointer fixedImage = ImageType::New();
   CreateFixedImage(fixedImage);
   


### PR DESCRIPTION
Fix unused type alias. Fixes:
```
[CTest: warning matched]
/home/lorensen/ProjectsGIT/DashboardsModules/Remote/WikiExamples/Registration/
LandmarkBasedTransformInitializer.cxx:17:36:
warning: typedef 'using VectorComponentType = float' locally defined but
not used [-Wunused-local-typedefs]
   using VectorComponentType = float;
```

signaled at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=5807048