### PR TITLE
DOC: Improve the `README` file.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,53 +10,18 @@ Overview
 
 The ITK WikiExamples can be built in several ways:
 
-1) A single example - go to the example page and follow instrutions
-2) All examples stand-alone go to
-   http://www.vtk.org/Wiki/ITK/Examples/Instructions/ForUsers#Build_all_of_the_examples
-3) All examples with a superbuild that builds a proper ITK and VTK - go to
-   http://www.vtk.org/Wiki/ITK/Examples/Instructions/ForUsers#Use_the_Superbuild_to_build_a_proper_VTK_and_ITK
-4) As an ITKv4 Remote Module proceed as follows.
+1. A single example. Follow the instrutions of the example.
+2. All examples stand-alone. Follow `these instructions <http://www.vtk.org/Wiki/ITK/Examples/Instructions/ForUsers#Build_all_of_the_examples>`_.
+3. All examples with a `Superbuild` that builds a proper ITK and VTK. Follow
+   `these guidelines <http://www.vtk.org/Wiki/ITK/Examples/Instructions/ForUsers#Use_the_Superbuild_to_build_a_proper_VTK_and_ITK>`_.
+4. As an ITK `Remote` Module. Follow these guidelines:
 
-* Enable fetching
-  1) Go to: https://github.com/InsightSoftwareConsortium/ITKWikiExamples/raw/master/WikiExamples.remote.cmake
-  2) Right click on the "Raw" button and select "Save Link As..."
-  3) Save the file in: YOUR_ITK_SOURCE_DIR/Modules/Remote
+   * Enable the `Module_WikiExamples` boolean variable in your ITK CMake file.
+   * Configure and generate your ITK project.
+   * Build the `WikiExamples` modules.
 
-A) If you use an interactive cmake (ccmake, cmake-gui or cmakesetup)
---------------------------------------------------------------------
-* Configure
-  1) Go to your itk build directory and run cmake
-  2) Configure
+If you want to test the `WikiExamples`, execute the follwoing commands::
 
-* NOTE: ITK 4.4 and earlier
-  Fetch ITK Wiki Examples
-  1) Open the highlighted (red) cmake entry
-  2) Check the Fetch_WikiExamples box
-  3) Configure
-
-* Enable ITK Wiki Exampes
-  1) Configure (yes, do it again)
-  2) Open the highlighted (red) cmake entry
-  3) Check the Module_WikiExamples box
-  4) Configure
-  5) Generate
-  6) Exit cmake
-
-B) If you use cmake from the command line
---------------------------------------
-From your itk build directory
-* Configure
-  1) NOTE: ITK 4.4 and earlier
-     cmake -DFetch_WikiExamples=ON YOUR_ITK_SOURCE_DIR
-  2) cmake -DModule_WikiExamples=ON YOUR_ITK_SOURCE_DIR
-
-Once you have configured using A) or B)
----------------------------------------
-* Build WikiExamples
-  From your itk build directory
-  1) make
-
-* Test WikiExamples if testing is ON
-  1) cd your itk build directory
-  2) cd Modules/Remote/WikiExamples
-  3) ctest
+  $ cd {itk_bld}
+  $ cd Modules/Remote/WikiExamples
+  $ ctest


### PR DESCRIPTION
Improve the `README` file:
- Improve the markup.
- Remove the `CMake` specific-instructions to reduce the clutter. The
  ITK `WikiExamples` are no different of other remotes in many ways.
- Remove the pre-`Remote Module` instructions: many examples will surely
  require ITKv4, and may be ITK v5.